### PR TITLE
fix(resources,schema): reflect apparent prosperworks changes

### DIFF
--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -461,7 +461,7 @@ class Opportunity(Resource, mixins.ReadWritable):
     customer_source = Related(CustomerSource)
     pipeline = Related(Pipeline)
     pipeline_stage = Related(PipelineStage)
-    primary_contact = Related(Person, required=True)
+    primary_contact = Related(Person)
     priority = fields.String(
         allow_none=True,
         validate=OneOf(choices=('None', 'Low', 'Medium', 'High')),

--- a/prospyr/schema.py
+++ b/prospyr/schema.py
@@ -55,7 +55,7 @@ class NamedTupleSchema(Schema):
 
 
 class EmailSchema(NamedTupleSchema):
-    email = fields.Email(allow_none=True)
+    email = fields.String(allow_none=True)
     category = fields.String()
 
 

--- a/prospyr/schema.py
+++ b/prospyr/schema.py
@@ -55,7 +55,7 @@ class NamedTupleSchema(Schema):
 
 
 class EmailSchema(NamedTupleSchema):
-    email = fields.Email()
+    email = fields.Email(allow_none=True)
     category = fields.String()
 
 


### PR DESCRIPTION
Since some time on 13 May 2016 it appears that a Person's email list may
contain empty "email addresses" and that an Opportunity no longer
requires a primary_contact Person.

I can’t find any information about this on their blog or in their documentation, so it might
be worth holding off merging this in until more information is available.

There was a new “Team Roles” feature launched on May 12th, but no clear
connection with the behaviour I saw (`prospyr.exceptions.ValidationError` raised regarding the fields modified by this MR.)
