### PR TITLE
Add webhooks as resource

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ The following ProsperWorks resources are supported by Prospyr:
 - PipelineStage (read–only)
 - Task (read–only)
 - User (read–only)
-- Webhook (read-only)
+- Webhook
 
 The following resources are not supported, but will still appear when
 referenced by the supported resources above. In this case, they come only with

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ A Python client library for ProsperWorks.
    :target: https://pypi.python.org/pypi/prospyr/
    :alt: Prospyr on Pypi.
 
-Prospyr runs on Python 2.7 or Python 3.4+. 
+Prospyr runs on Python 2.7 or Python 3.4+.
 
 Installation
 ============
@@ -78,6 +78,7 @@ The following ProsperWorks resources are supported by Prospyr:
 - PipelineStage (read–only)
 - Task (read–only)
 - User (read–only)
+- Webhook (read-only)
 
 The following resources are not supported, but will still appear when
 referenced by the supported resources above. In this case, they come only with

--- a/prospyr/__init__.py
+++ b/prospyr/__init__.py
@@ -8,5 +8,5 @@ from prospyr.connection import connect
 from prospyr.resources import (Account, Activity, ActivityType, Company,
                                CustomerSource, Identifier, Lead, LossReason,
                                Opportunity, Person, Pipeline, PipelineStage,
-                               Task, User)
+                               Task, User, Webhook)
 from prospyr.version import VERSION

--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -692,7 +692,7 @@ class Account(Resource, mixins.Singleton):
     id = fields.Integer()
     name = fields.String()
 
-class Webhook(Resource, mixins.Readable):
+class Webhook(Resource, mixins.Creatable, mixins.Readable, mixins.Deletable):
 
     class Meta(object):
         list_path = 'webhooks/'
@@ -705,7 +705,6 @@ class Webhook(Resource, mixins.Readable):
     event = fields.String(validate=OneOf(choices=('new', 'update', 'delete')))
     type = fields.String(validate=OneOf(choices=('lead', 'project', 'task', 'opportunity', 'company', 'person' )))
     secret = fields.Nested(schema.NamedTupleSchema, allow_none=True)
-
     date_created = Unix()
 
 class Placeholder(object):

--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -692,6 +692,21 @@ class Account(Resource, mixins.Singleton):
     id = fields.Integer()
     name = fields.String()
 
+class Webhook(Resource, mixins.Readable):
+
+    class Meta(object):
+        list_path = 'webhooks/'
+        detail_path = 'webhooks/{id}/'
+
+    objects = ListOnlyManager()
+
+    id = fields.Integer()
+    target = fields.String(required=True)
+    event = fields.String(validate=OneOf(choices=('new', 'update', 'delete')))
+    type = fields.String(validate=OneOf(choices=('lead', 'project', 'task', 'opportunity', 'company', 'person' )))
+    secret = fields.Nested(schema.NamedTupleSchema, allow_none=True)
+
+    date_created = Unix()
 
 class Placeholder(object):
     """


### PR DESCRIPTION
Adding webhooks as a resource
https://prosperworks.zendesk.com/hc/en-us/articles/217214766-ProsperWorks-Webhooks

Per the documentation, webhooks can be created, read, and deleted (but not updated). 

Since they don't have an search endpoint or a concept of ordering, I decided to do `objects = ListOnlyManager()` (even though they do have a `get` endpoint). The small performance loss by fetching all of the webhooks isn't that big of a concern (max webhooks = 100).